### PR TITLE
Improve API for f-strings used in elements

### DIFF
--- a/ludic/base.py
+++ b/ludic/base.py
@@ -11,6 +11,7 @@ class BaseElement(metaclass=ABCMeta):
     void_element: ClassVar[bool] = False
 
     formatter: ClassVar[FormatContext] = FormatContext("element_formatter")
+    formatter_fstring_wrap_in: ClassVar[type["BaseElement"] | None] = None
 
     children: Sequence[Any]
     attrs: Mapping[str, Any]
@@ -18,7 +19,9 @@ class BaseElement(metaclass=ABCMeta):
 
     def __init__(self, *children: Any, **attrs: Any) -> None:
         self.context = {}
-        self.children = children
+        self.children = self.formatter.extract(
+            *children, WrapIn=self.formatter_fstring_wrap_in
+        )
         self.attrs = attrs
 
     def __str__(self) -> str:

--- a/ludic/catalog/lists.py
+++ b/ludic/catalog/lists.py
@@ -1,13 +1,9 @@
 from typing import override
 
-from ludic.attrs import GlobalAttrs
+from ludic.attrs import GlobalAttrs, OlAttrs
 from ludic.components import Component
 from ludic.html import li, ol, ul
 from ludic.types import AnyChildren
-
-
-class ListAttrs(GlobalAttrs, total=False):
-    items: list[AnyChildren]
 
 
 class Item(Component[AnyChildren, GlobalAttrs]):
@@ -23,7 +19,7 @@ class Item(Component[AnyChildren, GlobalAttrs]):
         return li(*self.children, **self.attrs)
 
 
-class List(Component[Item, ListAttrs]):
+class List(Component[Item | str, GlobalAttrs]):
     """Simple component simulating a list.
 
     There is basically just an alias for the :class:`ul` element
@@ -31,19 +27,21 @@ class List(Component[Item, ListAttrs]):
 
     Example usage:
 
+        List("Item 1", "Item 2")
         List(Item("Item 1"), Item("Item 2"))
     """
 
+    formatter_fstring_wrap_in = Item
+
     @override
     def render(self) -> ul:
-        if items := self.attrs.get("items"):
-            children = tuple(map(Item, items))
-        else:
-            children = self.children
+        children = (
+            child if isinstance(child, Item) else Item(child) for child in self.children
+        )
         return ul(*children, **self.attrs_for(ul))
 
 
-class NumberedList(Component[Item, ListAttrs]):
+class NumberedList(Component[Item | str, OlAttrs]):
     """Simple component simulating a numbered list.
 
     There is basically just an alias for the :class:`ol` element
@@ -51,13 +49,15 @@ class NumberedList(Component[Item, ListAttrs]):
 
     Example usage:
 
+        NumberedList("Item 1", "Item 2")
         NumberedList(Item("Item 1"), Item("Item 2"))
     """
 
+    formatter_fstring_wrap_in = Item
+
     @override
     def render(self) -> ol:
-        if items := self.attrs.get("items"):
-            children = tuple(map(Item, items))
-        else:
-            children = self.children
+        children = (
+            child if isinstance(child, Item) else Item(child) for child in self.children
+        )
         return ol(*children, **self.attrs_for(ol))

--- a/ludic/catalog/typography.py
+++ b/ludic/catalog/typography.py
@@ -123,6 +123,9 @@ class CodeBlock(Component[str, CodeBlockAttrs]):
                 "padding-inline": theme.sizes.xxl,
                 "font-size": theme.fonts.size * 0.9,
             },
+            ".code-block *": {
+                "font-size": theme.fonts.size * 0.9,
+            },
         }
     )
 

--- a/ludic/elements.py
+++ b/ludic/elements.py
@@ -1,4 +1,4 @@
-from typing import Generic, Unpack, cast
+from typing import ClassVar, Generic, Unpack
 
 from .attrs import NoAttrs
 from .base import BaseElement
@@ -16,15 +16,15 @@ class Element(Generic[TChildren, TAttrs], BaseElement):
     children: tuple[TChildren, ...]
     attrs: TAttrs
 
+    formatter_wrap_in: ClassVar[type[BaseElement] | None] = None
+
     def __init__(
         self,
         *children: TChildren,
         # FIXME: https://github.com/python/typing/issues/1399
-        **attributes: Unpack[TAttrs],  # type: ignore
+        **attrs: Unpack[TAttrs],  # type: ignore
     ) -> None:
-        super().__init__()
-        self.attrs = cast(TAttrs, attributes)
-        self.children = tuple(self.formatter.extract(*children))
+        super().__init__(*children, **attrs)
 
 
 class ElementStrict(Generic[*TChildrenArgs, TAttrs], BaseElement):
@@ -38,15 +38,15 @@ class ElementStrict(Generic[*TChildrenArgs, TAttrs], BaseElement):
     children: tuple[*TChildrenArgs]
     attrs: TAttrs
 
+    formatter_wrap_in: ClassVar[type[BaseElement] | None] = None
+
     def __init__(
         self,
         *children: *TChildrenArgs,
         # FIXME: https://github.com/python/typing/issues/1399
         **attrs: Unpack[TAttrs],  # type: ignore
     ) -> None:
-        super().__init__()
-        self.attrs = cast(TAttrs, attrs)
-        self.children = tuple(self.formatter.extract(*children))
+        super().__init__(*children, **attrs)
 
 
 class Blank(Element[TChildren, NoAttrs]):
@@ -57,7 +57,7 @@ class Blank(Element[TChildren, NoAttrs]):
     """
 
     def __init__(self, *children: TChildren) -> None:
-        super().__init__(*self.formatter.extract(*children))
+        super().__init__(*children)
 
     def to_html(self) -> str:
         return "".join(map(str, self.children))

--- a/ludic/format.py
+++ b/ludic/format.py
@@ -192,7 +192,7 @@ class FormatContext:
 
         return f"{{{random_id}:id}}"
 
-    def extract(self, *args: Any) -> list[Any]:
+    def extract(self, *args: Any, WrapIn: type | None = None) -> tuple[Any, ...]:
         """Extract identifiers from the given arguments.
 
         Example:
@@ -205,24 +205,29 @@ class FormatContext:
             ["test ", "foo", " ", {"bar": "baz"}]
 
         Args:
+            WrapIn
             args (Any): The arguments to extract identifiers from.
 
         Returns:
             Any: The extracted arguments.
         """
-        extracted_args: list[Any] = []
+        arguments: list[Any] = []
         for arg in args:
             if isinstance(arg, str) and (parts := extract_identifiers(arg)):
                 cache = self.get()
-                extracted_args.extend(
+                extracted_args = (
                     cache.pop(part) if isinstance(part, int) else part
                     for part in parts
                     if not isinstance(part, int) or part in cache
                 )
+                if WrapIn is not None:
+                    arguments.append(WrapIn(*extracted_args))
+                else:
+                    arguments.extend(extracted_args)
                 self._context.set(cache)
             else:
-                extracted_args.append(arg)
-        return extracted_args
+                arguments.append(arg)
+        return tuple(arguments)
 
     def clear(self) -> None:
         """Clear the context memory."""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,7 @@
 from ludic.catalog.forms import ChoiceField, Form, InputField, TextAreaField
 from ludic.catalog.headers import H1, H2, H3, H4, Anchor
 from ludic.catalog.items import Key, Pairs, Value
+from ludic.catalog.lists import Item, List, NumberedList
 from ludic.catalog.messages import (
     Message,
     MessageDanger,
@@ -239,4 +240,23 @@ def test_choice_field() -> None:
                 '<label for="no">No</label>'
             '</div>'
         '</div>'
+    )  # fmt: skip
+
+
+def test_items() -> None:
+    assert List("A", "B", "C").to_html() == "<ul><li>A</li><li>B</li><li>C</li></ul>"
+    assert List(f"Test {b("yes")}", "D").to_html() == (
+        "<ul>"
+          "<li>Test <b>yes</b></li>"
+          "<li>D</li>"
+        "</ul>"
+    )  # fmt: skip
+    assert NumberedList(
+        Item(f"Test {b("ol")}"),
+        Item("E"),
+    ).to_html() == (
+        "<ol>"
+          "<li>Test <b>ol</b></li>"
+          "<li>E</li>"
+        "</ol>"
     )  # fmt: skip

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -35,7 +35,7 @@ def test_format_context() -> None:
         second = ctx.append({"bar": "baz"})
         extracts = ctx.extract(f"test {first} {second}")
 
-    assert extracts == ["test ", "foo", " ", {"bar": "baz"}]
+    assert extracts == ("test ", "foo", " ", {"bar": "baz"})
 
 
 def test_format_context_in_elements() -> None:
@@ -63,6 +63,7 @@ def test_component_with_f_string() -> None:
     paragraph = Paragraph(
         f"Hello, how {strong("are you")}? Click {Link("here", to="https://example.com")}.",
     )
+    assert len(paragraph.children) == 5
     assert isinstance(paragraph.children[3], Link)
     assert paragraph.children[3].attrs["to"] == "https://example.com"
     assert paragraph.to_string(pretty=False) == (


### PR DESCRIPTION
Instead of flattening `List(f"Test {b("bold")}")` into `List("Test ", b("bold"))` we wrap the f-string in an element specified by `formatter_fstring_wrap_in` (default is None). For `List`, this is what happens: `List(f"Test {b("bold")}") == List(Item("Test ", b("bold")))`.

This allows using e.g. lists like this: `List(f"Test {b("bold"}")` - this would create list with two elements without the `Format` helper element.